### PR TITLE
Don't call run-hooks two times

### DIFF
--- a/ctags-update.el
+++ b/ctags-update.el
@@ -272,9 +272,7 @@ not visiting a file"
   :init-value nil
   :group 'ctags-update
   (if ctags-auto-update-mode
-      (progn
-        (add-hook 'after-save-hook 'ctags-update nil t)
-        (run-hooks 'ctags-auto-update-mode-hook))
+      (add-hook 'after-save-hook 'ctags-update nil t)
     (remove-hook 'after-save-hook 'ctags-update t)))
 
 ;;;###autoload


### PR DESCRIPTION
define-minor-mode expands run-hooks call so you need not to call
run-hooks explicitly.